### PR TITLE
Feature/chat

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,0 +1,2 @@
+class EntriesController < ApplicationController
+end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -6,6 +6,7 @@ class EntriesController < ApplicationController
     elsif job_seeker_signed_in?
       @entry.update(job_seeker_id: nil)
     end
+    @entry.nobody
     redirect_to rooms_path, notice: 'ルームを退出しました'
   end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,2 +1,11 @@
 class EntriesController < ApplicationController
+  def destroy
+    @entry = current_user.entries.find_by(room_id: params[:id])
+    if current_job_offerer == @entry.job_offerer
+      @entry.update(job_offerer_id: nil)
+    elsif current_job_seeker == @entry.job_seeker
+      @entry.update(job_seeker_id: nil)
+    end
+    redirect_to rooms_path, notice: 'ルームを退出しました'
+  end
 end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,11 +1,7 @@
 class EntriesController < ApplicationController
   def destroy
     @entry = current_user.entries.find_by(room_id: params[:id])
-    if job_offerer_signed_in?
-      @entry.update(job_offerer_id: nil)
-    elsif job_seeker_signed_in?
-      @entry.update(job_seeker_id: nil)
-    end
+    current_user.leave(@entry)
     @entry.nobody
     redirect_to rooms_path, notice: 'ルームを退出しました'
   end

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,9 +1,9 @@
 class EntriesController < ApplicationController
   def destroy
     @entry = current_user.entries.find_by(room_id: params[:id])
-    if current_job_offerer == @entry.job_offerer
+    if job_offerer_signed_in?
       @entry.update(job_offerer_id: nil)
-    elsif current_job_seeker == @entry.job_seeker
+    elsif job_seeker_signed_in?
       @entry.update(job_seeker_id: nil)
     end
     redirect_to rooms_path, notice: 'ルームを退出しました'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,9 @@ module ApplicationHelper
       return true if @job_seeker == current_job_seeker
     end
   end
+
+  def room?
+    return true if controller.controller_name == 'rooms' &&
+                   controller.action_name == 'show'
+  end
 end

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,2 +1,5 @@
 module RoomsHelper
+  def both_present?
+    return true if @room.job_offerer.present? && @room.job_seeker.present?
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -2,4 +2,10 @@ class Entry < ApplicationRecord
   belongs_to :job_offerer, optional: true
   belongs_to :job_seeker, optional: true
   belongs_to :room
+
+  def nobody
+    return unless job_offerer_id.blank? && job_seeker_id.blank?
+
+    room.destroy
+  end
 end

--- a/app/models/job_offerer.rb
+++ b/app/models/job_offerer.rb
@@ -7,7 +7,7 @@ class JobOfferer < ApplicationRecord
 
   has_one :job_offerer_profile, dependent: :destroy
   has_many :job_postings, dependent: :destroy
-  has_many :messages, -> { where('job_seeker_id is NULL') }
-  has_many :entries
+  has_many :messages, -> { where('job_seeker_id is NULL') }, dependent: :nullify
+  has_many :entries, dependent: :nullify
   has_many :rooms, through: :entries
 end

--- a/app/models/job_offerer.rb
+++ b/app/models/job_offerer.rb
@@ -10,4 +10,8 @@ class JobOfferer < ApplicationRecord
   has_many :messages, -> { where('job_seeker_id is NULL') }, dependent: :nullify
   has_many :entries, dependent: :nullify
   has_many :rooms, through: :entries
+
+  def leave(entry)
+    entry.update(job_offerer_id: nil)
+  end
 end

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -7,7 +7,7 @@ class JobSeeker < ApplicationRecord
   
   has_one :job_seeker_profile, dependent: :destroy
   has_one :resume, dependent: :destroy
-  has_many :messages, -> { where('job_offerer_id is NULL') }
-  has_many :entries
+  has_many :messages, -> { where('job_offerer_id is NULL') }, dependent: :nullify
+  has_many :entries, dependent: :nullify
   has_many :rooms, through: :entries
 end

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -10,4 +10,8 @@ class JobSeeker < ApplicationRecord
   has_many :messages, -> { where('job_offerer_id is NULL') }, dependent: :nullify
   has_many :entries, dependent: :nullify
   has_many :rooms, through: :entries
+
+  def leave(entry)
+    entry.update(job_seeker_id: nil)
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,6 @@
 class Room < ApplicationRecord
-  has_many :messages
-  has_many :entries
+  has_many :messages, dependent: :destroy
+  has_many :entries, dependent: :destroy
   has_many :job_offerer, through: :entries
   has_many :job_seeker, through: :entries
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,22 +1,23 @@
-nav
-  .nav-wrapper
-    = link_to "JOBLINK", root_path, class: "brand-logo"
-    ul#nav-mobile.right.hide-on-med-and-down
-      - if job_offerer_signed_in?
-        li = link_to "マイページ", job_offerer_path(current_job_offerer)
-        li = link_to "ログアウト", destroy_job_offerer_session_path, method: :delete
-      -elsif job_seeker_signed_in?
-        li = link_to "マイページ", job_seeker_path(current_job_seeker)
-        li = link_to "ログアウト", destroy_job_seeker_session_path, method: :delete
-      - else
-        li 
-          a.dropdown-trigger href='#' data-target='dropdown-job-offerer' 
-            | 求人者の方はこちら
-            i.material-icons.right arrow_drop_down
-        li 
-          a.dropdown-trigger href='#' data-target='dropdown-job-seeker' 
-            | 求職者の方はこちら
-            i.material-icons.right arrow_drop_down
+.navbar-fixed
+  nav
+    .nav-wrapper
+      = link_to "JOBLINK", root_path, class: "brand-logo"
+      ul#nav-mobile.right.hide-on-med-and-down
+        - if job_offerer_signed_in?
+          li = link_to "マイページ", job_offerer_path(current_job_offerer)
+          li = link_to "ログアウト", destroy_job_offerer_session_path, method: :delete
+        -elsif job_seeker_signed_in?
+          li = link_to "マイページ", job_seeker_path(current_job_seeker)
+          li = link_to "ログアウト", destroy_job_seeker_session_path, method: :delete
+        - else
+          li 
+            a.dropdown-trigger href='#' data-target='dropdown-job-offerer' 
+              | 求人者の方はこちら
+              i.material-icons.right arrow_drop_down
+          li 
+            a.dropdown-trigger href='#' data-target='dropdown-job-seeker' 
+              | 求職者の方はこちら
+              i.material-icons.right arrow_drop_down
 ul#dropdown-job-offerer.dropdown-content
   li = link_to "サインアップ", new_job_offerer_registration_path
   li = link_to "ログイン", new_job_offerer_session_path

--- a/app/views/layouts/_room_header.html.slim
+++ b/app/views/layouts/_room_header.html.slim
@@ -6,7 +6,7 @@
           = link_to rooms_path, class: 'btn-flat' do
             i.material-icons.white-text chevron_left
         li
-          - if @room.job_offerer.present? && @room.job_seeker.present?
+          - if both_present?
             - if job_offerer_signed_in?  
               = @room.job_seeker.first.job_seeker_profile.full_name
             - elsif job_seeker_signed_in?

--- a/app/views/layouts/_room_header.html.slim
+++ b/app/views/layouts/_room_header.html.slim
@@ -1,0 +1,17 @@
+nav
+  .nav-wrapper
+    ul
+      li 
+        = link_to rooms_path, class: 'btn-flat' do
+          i.material-icons.white-text chevron_left
+      li
+        - if @room.job_offerer.present? && @room.job_seeker.present?
+          - if job_offerer_signed_in?  
+            = @room.job_seeker.first.job_seeker_profile.full_name
+          - elsif job_seeker_signed_in?
+            = @room.job_offerer.first.job_offerer_profile.full_name
+        - else
+          | 相手が退出しています
+      li.right
+        = link_to room_entry_path(@room), method: :delete, data: {confirm: 'このルームから退出しますか?このルームでの会話は見られなくなります。'}, class: 'btn-flat' do
+          i.material-icons.white-text exit_to_app

--- a/app/views/layouts/_room_header.html.slim
+++ b/app/views/layouts/_room_header.html.slim
@@ -1,17 +1,18 @@
-nav
-  .nav-wrapper
-    ul
-      li 
-        = link_to rooms_path, class: 'btn-flat' do
-          i.material-icons.white-text chevron_left
-      li
-        - if @room.job_offerer.present? && @room.job_seeker.present?
-          - if job_offerer_signed_in?  
-            = @room.job_seeker.first.job_seeker_profile.full_name
-          - elsif job_seeker_signed_in?
-            = @room.job_offerer.first.job_offerer_profile.full_name
-        - else
-          | 相手が退出しています
-      li.right
-        = link_to room_entry_path(@room), method: :delete, data: {confirm: 'このルームから退出しますか?このルームでの会話は見られなくなります。'}, class: 'btn-flat' do
-          i.material-icons.white-text exit_to_app
+.navbar-fixed
+  nav
+    .nav-wrapper
+      ul
+        li 
+          = link_to rooms_path, class: 'btn-flat' do
+            i.material-icons.white-text chevron_left
+        li
+          - if @room.job_offerer.present? && @room.job_seeker.present?
+            - if job_offerer_signed_in?  
+              = @room.job_seeker.first.job_seeker_profile.full_name
+            - elsif job_seeker_signed_in?
+              = @room.job_offerer.first.job_offerer_profile.full_name
+          - else
+            | 相手が退出しています
+        li.right
+          = link_to room_entry_path(@room), method: :delete, data: {confirm: 'このルームから退出しますか?このルームでの会話は見られなくなります。'}, class: 'btn-flat' do
+            i.material-icons.white-text exit_to_app

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,7 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     link[href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"]
   body
-    -if controller.controller_name == 'rooms' && controller.action_name == 'show'
+    - if room?
       = render 'layouts/room_header'
     - else  
       = render 'layouts/header'
@@ -19,5 +19,5 @@ html
       = alert
     .container
       = yield
-    - unless controller.controller_name == 'rooms' && controller.action_name == 'show' 
+    - unless room?
       = render 'layouts/footer'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,10 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     link[href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"]
   body
-    = render 'layouts/header'
+    -if controller.controller_name == 'rooms' && controller.action_name == 'show'
+      = render 'layouts/room_header'
+    - else  
+      = render 'layouts/header'
     p.notice
       = notice
     p.alert

--- a/app/views/rooms/_job_offerers.html.slim
+++ b/app/views/rooms/_job_offerers.html.slim
@@ -1,11 +1,16 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
-    - if room.job_seeker.first.job_seeker_profile.avatar.attached?
-      = image_tag room.job_seeker.first.job_seeker_profile.shaped_avatar, class: 'circle'
+    - if room.job_seeker.first
+      - if room.job_seeker.first.job_seeker_profile.avatar.attached?
+        = image_tag room.job_seeker.first.job_seeker_profile.shaped_avatar, class: 'circle'
+      - else 
+        = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
+      span.title
+        = room.job_seeker.first.job_seeker_profile.full_name
     - else 
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
-    span.title
-      = room.job_seeker.first.job_seeker_profile.full_name
+      span.title
+        | 相手が退出しています。
     p.right
       = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
     p

--- a/app/views/rooms/_job_offerers.html.slim
+++ b/app/views/rooms/_job_offerers.html.slim
@@ -11,9 +11,10 @@
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title
         | 相手が退出しています。
-    p.right
-      = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
-    p
-      - if room.messages.last.job_offerer == current_job_offerer
-        | あなた: 
-      = room.messages.last.content.truncate(28, omission: '...')
+    - if room.messages.present?
+      p.right
+        = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
+      p
+        - if room.messages.last.job_offerer == current_job_offerer
+          | あなた: 
+        = room.messages.last.content.truncate(28, omission: '...')

--- a/app/views/rooms/_job_offerers.html.slim
+++ b/app/views/rooms/_job_offerers.html.slim
@@ -1,6 +1,6 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
-    - if room.job_seeker.first
+    - if room.job_seeker.present?
       - if room.job_seeker.first.job_seeker_profile.avatar.attached?
         = image_tag room.job_seeker.first.job_seeker_profile.shaped_avatar, class: 'circle'
       - else 

--- a/app/views/rooms/_job_seekers.html.slim
+++ b/app/views/rooms/_job_seekers.html.slim
@@ -1,11 +1,16 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
-    - if room.job_offerer.first.job_offerer_profile.avatar.attached?
-      = image_tag room.job_offerer.first.job_offerer_profile.shaped_avatar, class: 'circle'
-    - else 
+    - if room.job_offerer.first
+      - if room.job_offerer.first.job_offerer_profile.avatar.attached?
+        = image_tag room.job_offerer.first.job_offerer_profile.shaped_avatar, class: 'circle'
+      - else 
+        = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
+      span.title
+        = room.job_offerer.first.job_offerer_profile.full_name
+    - else
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
-    span.title
-      = room.job_offerer.first.job_offerer_profile.full_name
+      span.title
+        | 相手が退出しています。
     p.right
       = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
     p

--- a/app/views/rooms/_job_seekers.html.slim
+++ b/app/views/rooms/_job_seekers.html.slim
@@ -1,6 +1,6 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
-    - if room.job_offerer.first
+    - if room.job_offerer.present?
       - if room.job_offerer.first.job_offerer_profile.avatar.attached?
         = image_tag room.job_offerer.first.job_offerer_profile.shaped_avatar, class: 'circle'
       - else 

--- a/app/views/rooms/_job_seekers.html.slim
+++ b/app/views/rooms/_job_seekers.html.slim
@@ -11,9 +11,10 @@
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title
         | 相手が退出しています。
-    p.right
-      = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
-    p
-      - if room.messages.last.job_seeker == current_job_seeker
-        | あなた: 
-      = room.messages.last.content.truncate(28, omission: '...')
+    - if room.messages.present?
+      p.right
+        = room.messages.last.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
+      p
+        - if room.messages.last.job_seeker == current_job_seeker
+          | あなた: 
+        = room.messages.last.content.truncate(28, omission: '...')

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -1,5 +1,15 @@
-h1
-  | トークルーム
+.section
+  = link_to rooms_path, class: 'btn-flat' do
+    i.material-icons chevron_left
+  - if @room.job_offerer.first && @room.job_seeker.first
+    - if job_offerer_signed_in?  
+      = @room.job_seeker.first.job_seeker_profile.full_name
+    - elsif job_seeker_signed_in?
+      = @room.job_offerer.first.job_offerer_profile.full_name
+  - else
+    | 相手が退出しています
+  = link_to room_entry_path(@room), method: :delete, data: {confirm: 'このルームから退出しますか?このルームでの会話は見られなくなります。'}, class: 'btn-flat right' do
+    i.material-icons exit_to_app
 table.highlight#messages data-room_id="#{ @room.id }"
   tbody
     = render @messages

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -1,7 +1,7 @@
 .section
   = link_to rooms_path, class: 'btn-flat' do
     i.material-icons chevron_left
-  - if @room.job_offerer.first && @room.job_seeker.first
+  - if @room.job_offerer.present? && @room.job_seeker.present?
     - if job_offerer_signed_in?  
       = @room.job_seeker.first.job_seeker_profile.full_name
     - elsif job_seeker_signed_in?

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -1,15 +1,3 @@
-.section
-  = link_to rooms_path, class: 'btn-flat' do
-    i.material-icons chevron_left
-  - if @room.job_offerer.present? && @room.job_seeker.present?
-    - if job_offerer_signed_in?  
-      = @room.job_seeker.first.job_seeker_profile.full_name
-    - elsif job_seeker_signed_in?
-      = @room.job_offerer.first.job_offerer_profile.full_name
-  - else
-    | 相手が退出しています
-  = link_to room_entry_path(@room), method: :delete, data: {confirm: 'このルームから退出しますか?このルームでの会話は見られなくなります。'}, class: 'btn-flat right' do
-    i.material-icons exit_to_app
 table.highlight#messages data-room_id="#{ @room.id }"
   tbody
     = render @messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :rooms, only: %i[index show create]
+  resources :rooms, only: %i[index show create] do
+    resources :entries, only: :destroy
+  end
 
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
### トークルーム退出機能を追加

RoomのEntryで参照されている自分のidをNULLにすることで実現。

例えば、AとBがチャットをしているとき、
1.  Aが退出すると、AのRoom閲覧権限が失われ、Bだけが閲覧できるようになる。このとき、AのMessageは消えない。
2. 続けてBが退出するとBのRoom閲覧権限が失われると同時にRoomが削除され、紐づいたMessageとEntryも削除される

Roomを直接削除する昨日は未検討。
やるなら管理者権限にした方がよいだろう。