### PR TITLE
Feature/profile

### DIFF
--- a/app/controllers/job_offerers/confirmations_controller.rb
+++ b/app/controllers/job_offerers/confirmations_controller.rb
@@ -27,7 +27,7 @@ class JobOfferers::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(resource_name, resource)
     # super(resource_name, resource)
     sign_in(resource)
-    if current_job_offerer.job_offerer_profile.blank?
+    if current_job_offerer.profile.blank?
       flash[:notice] = 'メールアドレスが認証されました。続いてプロフィールを登録してください'
       new_job_offerer_profile_path(resource)
     else

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -11,11 +11,11 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def new
-    @profile = current_job_offerer.build_job_offerer_profile
+    @profile = current_job_offerer.build_profile
   end
 
   def create
-    @profile = current_job_offerer.build_job_offerer_profile(profile_params)
+    @profile = current_job_offerer.build_profile(profile_params)
     if @profile.save
       redirect_to root_url, notice: 'プロフィール設定が完了しました'
     else
@@ -24,11 +24,11 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = current_job_offerer.job_offerer_profile
+    @profile = current_job_offerer.profile
   end
 
   def update
-    @profile = current_job_offerer.job_offerer_profile
+    @profile = current_job_offerer.profile
     if @profile.update_attributes(profile_params)
       redirect_to current_job_offerer, notice: 'プロフィールの更新に成功しました'
     else

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -7,7 +7,7 @@ class JobOfferers::ProfilesController < ApplicationController
 
   def show
     @job_offerer = JobOfferer.find(params[:id])
-    @profile = @job_offerer.job_offerer_profile
+    @profile = @job_offerer.profile
   end
 
   def new

--- a/app/controllers/job_seekers/confirmations_controller.rb
+++ b/app/controllers/job_seekers/confirmations_controller.rb
@@ -27,7 +27,7 @@ class JobSeekers::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(resource_name, resource)
     # super(resource_name, resource)
     sign_in(resource)
-    if current_job_seeker.job_seeker_profile.blank?
+    if current_job_seeker.profile.blank?
       flash[:notice] = 'メールアドレスが認証されました。続いてプロフィールを登録してください'
       new_job_seeker_profile_path(resource)
     else

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -7,7 +7,7 @@ class JobSeekers::ProfilesController < ApplicationController
 
   def show
     @job_seeker = JobSeeker.find(params[:id])
-    @profile = @job_seeker.job_seeker_profile
+    @profile = @job_seeker.profile
   end
 
   def new

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -11,11 +11,11 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def new
-    @profile = current_job_seeker.build_job_seeker_profile
+    @profile = current_job_seeker.build_profile
   end
 
   def create
-    @profile = current_job_seeker.build_job_seeker_profile(profile_params)
+    @profile = current_job_seeker.build_profile(profile_params)
     if @profile.save
       redirect_to root_url, notice: 'プロフィール設定が完了しました'
     else
@@ -24,11 +24,11 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = current_job_seeker.job_seeker_profile
+    @profile = current_job_seeker.profile
   end
 
   def update
-    @profile = current_job_seeker.job_seeker_profile
+    @profile = current_job_seeker.profile
     if @profile.update_attributes(profile_params)
       redirect_to current_job_seeker, notice: 'プロフィールの更新に成功しました'
     else

--- a/app/helpers/job_offerers/informations_helper.rb
+++ b/app/helpers/job_offerers/informations_helper.rb
@@ -1,2 +1,0 @@
-module JobOfferers::InformationsHelper
-end

--- a/app/helpers/job_offerers/profiles_helper.rb
+++ b/app/helpers/job_offerers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module JobOfferers::ProfilesHelper
+end

--- a/app/models/job_offerer.rb
+++ b/app/models/job_offerer.rb
@@ -5,7 +5,7 @@ class JobOfferer < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable, :lockable, :timeoutable
 
-  has_one :job_offerer_profile, dependent: :destroy
+  has_one :profile, class_name: 'JobOffererProfile', dependent: :destroy
   has_many :job_postings, dependent: :destroy
   has_many :messages, -> { where('job_seeker_id is NULL') }, dependent: :nullify
   has_many :entries, dependent: :nullify

--- a/app/models/job_seeker.rb
+++ b/app/models/job_seeker.rb
@@ -5,7 +5,7 @@ class JobSeeker < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable, :lockable, :timeoutable
   
-  has_one :job_seeker_profile, dependent: :destroy
+  has_one :profile, class_name: 'JobSeekerProfile', dependent: :destroy
   has_one :resume, dependent: :destroy
   has_many :messages, -> { where('job_offerer_id is NULL') }, dependent: :nullify
   has_many :entries, dependent: :nullify

--- a/app/views/job_offerers/profiles/index.html.slim
+++ b/app/views/job_offerers/profiles/index.html.slim
@@ -3,7 +3,7 @@ h2
 .section
   .collection
     - @profiles.each do |profile|
-       = link_to(job_offerer_path(profile), class: 'collection-item avatar black-text') do
+       = link_to(job_offerer_path(profile.job_offerer), class: 'collection-item avatar black-text') do
         - if profile.avatar.attached?
           = image_tag profile.shaped_avatar, class: 'circle'
           span.title

--- a/app/views/job_seekers/profiles/index.html.slim
+++ b/app/views/job_seekers/profiles/index.html.slim
@@ -3,7 +3,7 @@ h2
 .section
   .collection
     - @profiles.each do |profile|
-       = link_to(job_seeker_path(profile), class: 'collection-item avatar black-text') do
+       = link_to(job_seeker_path(profile.job_seeker), class: 'collection-item avatar black-text') do
         - if profile.avatar.attached?
           = image_tag profile.shaped_avatar, class: 'circle'
           span.title

--- a/app/views/layouts/_room_header.html.slim
+++ b/app/views/layouts/_room_header.html.slim
@@ -8,9 +8,9 @@
         li
           - if both_present?
             - if job_offerer_signed_in?  
-              = @room.job_seeker.first.job_seeker_profile.full_name
+              = @room.job_seeker.first.profile.full_name
             - elsif job_seeker_signed_in?
-              = @room.job_offerer.first.job_offerer_profile.full_name
+              = @room.job_offerer.first.profile.full_name
           - else
             | 相手が退出しています
         li.right

--- a/app/views/messages/_message.html.slim
+++ b/app/views/messages/_message.html.slim
@@ -1,12 +1,12 @@
 tr
   td
     - if message.job_offerer
-      strong = message.job_offerer.job_offerer_profile.full_name
+      strong = message.job_offerer.profile.full_name
       .right
         = message.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
       p = simple_format(message.content)
     - elsif message.job_seeker
-      strong = message.job_seeker.job_seeker_profile.full_name
+      strong = message.job_seeker.profile.full_name
       .right
         = message.updated_at.in_time_zone('Tokyo').strftime('%Y/%m/%d %H:%M')
       p = simple_format(message.content)

--- a/app/views/rooms/_job_offerers.html.slim
+++ b/app/views/rooms/_job_offerers.html.slim
@@ -1,12 +1,12 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
     - if room.job_seeker.present?
-      - if room.job_seeker.first.job_seeker_profile.avatar.attached?
-        = image_tag room.job_seeker.first.job_seeker_profile.shaped_avatar, class: 'circle'
+      - if room.job_seeker.first.profile.avatar.attached?
+        = image_tag room.job_seeker.first.profile.shaped_avatar, class: 'circle'
       - else 
         = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title
-        = room.job_seeker.first.job_seeker_profile.full_name
+        = room.job_seeker.first.profile.full_name
     - else 
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title

--- a/app/views/rooms/_job_seekers.html.slim
+++ b/app/views/rooms/_job_seekers.html.slim
@@ -1,12 +1,12 @@
 - @rooms.each do |room|
   = link_to(room_path(room), class: 'collection-item avatar black-text') do
     - if room.job_offerer.present?
-      - if room.job_offerer.first.job_offerer_profile.avatar.attached?
-        = image_tag room.job_offerer.first.job_offerer_profile.shaped_avatar, class: 'circle'
+      - if room.job_offerer.first.profile.avatar.attached?
+        = image_tag room.job_offerer.first.profile.shaped_avatar, class: 'circle'
       - else 
         = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title
-        = room.job_offerer.first.job_offerer_profile.full_name
+        = room.job_offerer.first.profile.full_name
     - else
       = image_tag '/default_avatar.png', class: 'circle', size: '200x200'
       span.title


### PR DESCRIPTION
### JobOfferer/SeekerとJobOffererProfile/JobSeekerProfileのアソシエーション名を変更

以下のような理由で、もっと簡単にプロフィールの値をとりたいと考えた。
- 共通の処理を書くのが困難なケースが出てくる
- 'job_offerer.job_offerer_profile'のように書くのが煩わしい

そこで、アソシエーションのオプションである'class_name: "ClassName"を使用。
これにより、'job_offerer.profile'で値がとれるようになり、それに伴い既存のコードを変更した。

参考:
(https://railsguides.jp/association_basics.html#has-one%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91%E3%81%AE%E8%A9%B3%E7%B4%B0)
(http://beck23.hatenablog.com/entry/2014/09/09/145327#6)