### PR TITLE
Feature/access restriction

### DIFF
--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -1,0 +1,21 @@
+module Common
+  extend ActiveSupport::Concern
+
+  def profile_exists_already
+    return redirect_to root_url, alert: '操作が無効です' unless current_user.profile.nil?
+  end
+
+  def profile_require_correct_user
+    if job_offerer_signed_in?
+      @profile = JobOffererProfile.find(params[:job_offerer_id])
+      return unless @profile.job_offerer != current_job_offerer
+
+      redirect_back(fallback_location: root_path, alert: '権限がありません')
+    elsif job_seeker_signed_in?
+      @profile = JobSeekerProfile.find(params[:job_seeker_id])
+      return unless @profile.job_seeker != current_job_seeker
+
+      redirect_back(fallback_location: root_path, alert: '権限がありません')
+    end
+  end
+end

--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -1,6 +1,18 @@
 module Common
   extend ActiveSupport::Concern
 
+  def require_profile
+    return unless current_user.profile.nil?
+
+    if job_offerer_signed_in?
+      redirect_to new_job_offerer_profile_path(current_user)
+      flash[:notice] = 'この機能はプロフィールの設定が必要です'
+    elsif job_seeker_signed_in?
+      redirect_to new_job_seeker_profile_path(current_user)
+      flash[:notice] = 'この機能はプロフィールの設定が必要です'
+    end
+  end
+
   def profile_exists_already
     return redirect_to root_url, alert: '操作が無効です' unless current_user.profile.nil?
   end

--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -17,15 +17,15 @@ module Common
     return redirect_to root_url, alert: '操作が無効です' unless current_user.profile.nil?
   end
 
-  def profile_require_correct_user
+  def require_correct_user
     if job_offerer_signed_in?
-      @profile = JobOffererProfile.find(params[:job_offerer_id])
-      return unless @profile.job_offerer != current_job_offerer
+      @job_offerer = JobOfferer.find(params[:job_offerer_id])
+      return unless @job_offerer != current_job_offerer
 
       redirect_back(fallback_location: root_path, alert: '権限がありません')
     elsif job_seeker_signed_in?
-      @profile = JobSeekerProfile.find(params[:job_seeker_id])
-      return unless @profile.job_seeker != current_job_seeker
+      @job_seeker = JobSeeker.find(params[:job_seeker_id])
+      return unless @job_seeker != current_job_seeker
 
       redirect_back(fallback_location: root_path, alert: '権限がありません')
     end

--- a/app/controllers/job_offerers/job_postings_controller.rb
+++ b/app/controllers/job_offerers/job_postings_controller.rb
@@ -3,7 +3,7 @@ class JobOfferers::JobPostingsController < ApplicationController
 
   before_action :authenticate_job_offerer!, except: %i[index show]
   before_action :require_profile, except: %i[index show]
-  before_action :posting_require_correct_user, only: %i[edit update destroy]
+  before_action :posting_requires_correct_user, only: %i[edit update destroy]
 
   def index
     @job_postings = JobPosting.order(updated_at: :desc).page(params[:page]).per(5)
@@ -56,7 +56,7 @@ class JobOfferers::JobPostingsController < ApplicationController
     )
   end
 
-  def posting_require_correct_user
+  def posting_requires_correct_user
     @job_posting = JobPosting.find(params[:id])
     return unless @job_posting.job_offerer != current_job_offerer
 

--- a/app/controllers/job_offerers/job_postings_controller.rb
+++ b/app/controllers/job_offerers/job_postings_controller.rb
@@ -1,5 +1,8 @@
 class JobOfferers::JobPostingsController < ApplicationController
+  include Common
+
   before_action :authenticate_job_offerer!, except: %i[index show]
+  before_action :require_profile, except: %i[index show]
   before_action :posting_require_correct_user, only: %i[edit update destroy]
 
   def index

--- a/app/controllers/job_offerers/job_postings_controller.rb
+++ b/app/controllers/job_offerers/job_postings_controller.rb
@@ -1,5 +1,6 @@
 class JobOfferers::JobPostingsController < ApplicationController
   before_action :authenticate_job_offerer!, except: %i[index show]
+  before_action :posting_require_correct_user, only: %i[edit update destroy]
 
   def index
     @job_postings = JobPosting.order(updated_at: :desc).page(params[:page]).per(5)
@@ -50,5 +51,12 @@ class JobOfferers::JobPostingsController < ApplicationController
       :title,
       :content
     )
+  end
+
+  def posting_require_correct_user
+    @job_posting = JobPosting.find(params[:id])
+    return unless @job_posting.job_offerer != current_job_offerer
+
+    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -12,6 +12,8 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def new
+    return redirect_to root_url, alert: '操作が無効です' unless current_job_offerer.profile.nil?
+
     @profile = current_job_offerer.build_profile
   end
 

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -28,11 +28,11 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = JobOffererProfile.find(params[:job_offerer_id])
+    @profile = JobOffererProfile.find_by(job_offerer_id: params[:job_offerer_id])
   end
 
   def update
-    @profile = JobOffererProfile.find(params[:job_offerer_id])
+    @profile = JobOffererProfile.find_by(job_offerer_id: params[:job_offerer_id])
     if @profile.update_attributes(profile_params)
       redirect_to @profile.job_offerer, notice: 'プロフィールの更新に成功しました'
     else

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -3,7 +3,7 @@ class JobOfferers::ProfilesController < ApplicationController
 
   before_action :authenticate_job_offerer!, except: %i[index show]
   before_action :profile_exists_already, only: %i[new create]
-  before_action :profile_require_correct_user, only: %i[edit update]
+  before_action :require_correct_user, only: %i[edit update]
 
   def index
     @profiles = JobOffererProfile.page(params[:page])

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -24,13 +24,13 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = current_job_offerer.profile
+    @profile = JobOffererProfile.find(params[:job_offerer_id])
   end
 
   def update
-    @profile = current_job_offerer.profile
+    @profile = JobOffererProfile.find(params[:job_offerer_id])
     if @profile.update_attributes(profile_params)
-      redirect_to current_job_offerer, notice: 'プロフィールの更新に成功しました'
+      redirect_to @profile.job_offerer, notice: 'プロフィールの更新に成功しました'
     else
       render 'edit', alert: 'プロフィールの更新に失敗しました'
     end

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class JobOfferers::ProfilesController < ApplicationController
   before_action :authenticate_job_offerer!, except: %i[index show]
+  before_action :profile_require_correct_user, only: %i[edit update]
 
   def index
     @profiles = JobOffererProfile.page(params[:page])
@@ -46,5 +47,13 @@ class JobOfferers::ProfilesController < ApplicationController
       :bio,
       :avatar
     )
+  end
+
+  def profile_require_correct_user
+    @profile = JobOffererProfile.find(params[:job_offerer_id])
+    return unless @profile.present?
+    return unless @profile.job_offerer != current_job_offerer
+
+    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -1,5 +1,8 @@
 class JobOfferers::ProfilesController < ApplicationController
+  include Common
+
   before_action :authenticate_job_offerer!, except: %i[index show]
+  before_action :profile_exists_already, only: %i[new create]
   before_action :profile_require_correct_user, only: %i[edit update]
 
   def index
@@ -12,8 +15,6 @@ class JobOfferers::ProfilesController < ApplicationController
   end
 
   def new
-    return redirect_to root_url, alert: '操作が無効です' unless current_job_offerer.profile.nil?
-
     @profile = current_job_offerer.build_profile
   end
 
@@ -49,13 +50,5 @@ class JobOfferers::ProfilesController < ApplicationController
       :bio,
       :avatar
     )
-  end
-
-  def profile_require_correct_user
-    @profile = JobOffererProfile.find(params[:job_offerer_id])
-    return unless @profile.present?
-    return unless @profile.job_offerer != current_job_offerer
-
-    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -3,7 +3,7 @@ class JobSeekers::ProfilesController < ApplicationController
 
   before_action :authenticate_job_seeker!, except: %i[index show]
   before_action :profile_exists_already, only: %i[new create]
-  before_action :profile_require_correct_user, only: %i[edit update]
+  before_action :require_correct_user, only: %i[edit update]
 
   def index
     @profiles = JobSeekerProfile.page(params[:page])

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -1,5 +1,8 @@
 class JobSeekers::ProfilesController < ApplicationController
+  include Common
+
   before_action :authenticate_job_seeker!, except: %i[index show]
+  before_action :profile_exists_already, only: %i[new create]
   before_action :profile_require_correct_user, only: %i[edit update]
 
   def index
@@ -12,8 +15,6 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def new
-    return redirect_to root_url, alert: '操作が無効です' unless current_job_seeker.profile.nil?
-
     @profile = current_job_seeker.build_profile
   end
 
@@ -49,13 +50,5 @@ class JobSeekers::ProfilesController < ApplicationController
       :bio,
       :avatar
     )
-  end
-
-  def profile_require_correct_user
-    @profile = JobSeekerProfile.find(params[:job_seeker_id])
-    return unless @profile.present?
-    return unless @profile.job_seeker != current_job_seeker
-
-    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class JobSeekers::ProfilesController < ApplicationController
   before_action :authenticate_job_seeker!, except: %i[index show]
+  before_action :profile_require_correct_user, only: %i[edit update]
 
   def index
     @profiles = JobSeekerProfile.page(params[:page])
@@ -47,5 +48,13 @@ class JobSeekers::ProfilesController < ApplicationController
       :resume,
       :avatar
     )
+  end
+
+  def profile_require_correct_user
+    @profile = JobSeekerProfile.find(params[:job_seeker_id])
+    return unless @profile.present?
+    return unless @profile.job_seeker != current_job_seeker
+
+    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -24,13 +24,13 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = current_job_seeker.profile
+    @profile = JobSeekerProfile.find(params[:job_seeker_id])
   end
 
   def update
-    @profile = current_job_seeker.profile
+    @profile = JobSeekerProfile.find(params[:job_seeker_id])
     if @profile.update_attributes(profile_params)
-      redirect_to current_job_seeker, notice: 'プロフィールの更新に成功しました'
+      redirect_to @profile.job_seeker, notice: 'プロフィールの更新に成功しました'
     else
       render 'edit', alert: 'プロフィールの更新に失敗しました'
     end

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -28,11 +28,11 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def edit
-    @profile = JobSeekerProfile.find(params[:job_seeker_id])
+    @profile = JobSeekerProfile.find_by(job_seeker_id: params[:job_seeker_id])
   end
 
   def update
-    @profile = JobSeekerProfile.find(params[:job_seeker_id])
+    @profile = JobSeekerProfile.find_by(job_seeker_id: params[:job_seeker_id])
     if @profile.update_attributes(profile_params)
       redirect_to @profile.job_seeker, notice: 'プロフィールの更新に成功しました'
     else

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -12,6 +12,8 @@ class JobSeekers::ProfilesController < ApplicationController
   end
 
   def new
+    return redirect_to root_url, alert: '操作が無効です' unless current_job_seeker.profile.nil?
+
     @profile = current_job_seeker.build_profile
   end
 

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -45,7 +45,6 @@ class JobSeekers::ProfilesController < ApplicationController
       :first_name_furigana,
       :last_name_furigana,
       :bio,
-      :resume,
       :avatar
     )
   end

--- a/app/controllers/job_seekers/resumes_controller.rb
+++ b/app/controllers/job_seekers/resumes_controller.rb
@@ -3,7 +3,7 @@ class JobSeekers::ResumesController < ApplicationController
 
   before_action :authenticate_job_seeker!
   before_action :require_profile
-  before_action :resume_require_correct_user
+  before_action :require_correct_user
 
   def new
     @resume = current_job_seeker.build_resume
@@ -43,12 +43,5 @@ class JobSeekers::ResumesController < ApplicationController
     params.require(:resume).permit(
       :content
     )
-  end
-
-  def resume_require_correct_user
-    @job_seeker = JobSeeker.find(params[:job_seeker_id])
-    return unless @job_seeker != current_job_seeker
-
-    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_seekers/resumes_controller.rb
+++ b/app/controllers/job_seekers/resumes_controller.rb
@@ -1,6 +1,6 @@
 class JobSeekers::ResumesController < ApplicationController
   before_action :authenticate_job_seeker!
-  before_action :correct_job_seeker
+  before_action :resume_require_correct_user
 
   def new
     @resume = current_job_seeker.build_resume
@@ -42,11 +42,10 @@ class JobSeekers::ResumesController < ApplicationController
     )
   end
 
-  def correct_job_seeker
+  def resume_require_correct_user
     @job_seeker = JobSeeker.find(params[:job_seeker_id])
-    return if @job_seeker == current_job_seeker
+    return unless @job_seeker != current_job_seeker
 
-    redirect_back(fallback_location: root_path)
-    flash[:alert] = '権限がありません'
+    redirect_back(fallback_location: root_path, alert: '権限がありません')
   end
 end

--- a/app/controllers/job_seekers/resumes_controller.rb
+++ b/app/controllers/job_seekers/resumes_controller.rb
@@ -1,5 +1,8 @@
 class JobSeekers::ResumesController < ApplicationController
+  include Common
+
   before_action :authenticate_job_seeker!
+  before_action :require_profile
   before_action :resume_require_correct_user
 
   def new

--- a/app/controllers/job_seekers/resumes_controller.rb
+++ b/app/controllers/job_seekers/resumes_controller.rb
@@ -16,11 +16,11 @@ class JobSeekers::ResumesController < ApplicationController
   end
 
   def edit
-    @resume = current_job_seeker.resume
+    @resume = JobSeeker.find(params[:job_seeker_id]).resume
   end
 
   def update
-    @resume = current_job_seeker.resume
+    @resume = JobSeeker.find(params[:job_seeker_id]).resume
     if @resume.update_attributes(resume_params)
       redirect_to job_seeker_path(current_job_seeker), notice: '経歴書を更新しました'
     else
@@ -29,8 +29,8 @@ class JobSeekers::ResumesController < ApplicationController
   end
 
   def destroy
-    @job_seeker = JobSeeker.find(params[:job_seeker_id])
-    if @job_seeker.resume.destroy
+    @resume = JobSeeker.find(params[:job_seeker_id]).resume
+    if @resume.destroy
       redirect_to job_seeker_path(@job_seeker), notice: '経歴書を削除しました。'
     else
       redirect_to job_seeker_path(@job_seeker), alert: '経歴書の削除に失敗しました。'

--- a/app/controllers/job_seekers/resumes_controller.rb
+++ b/app/controllers/job_seekers/resumes_controller.rb
@@ -22,19 +22,16 @@ class JobSeekers::ResumesController < ApplicationController
   def update
     @resume = JobSeeker.find(params[:job_seeker_id]).resume
     if @resume.update_attributes(resume_params)
-      redirect_to job_seeker_path(current_job_seeker), notice: '経歴書を更新しました'
+      redirect_to job_seeker_path(@resume.job_seeker), notice: '経歴書を更新しました'
     else
       render 'edit', alert: '経歴書の更新に失敗しました'
     end
   end
 
   def destroy
-    @resume = JobSeeker.find(params[:job_seeker_id]).resume
-    if @resume.destroy
-      redirect_to job_seeker_path(@job_seeker), notice: '経歴書を削除しました。'
-    else
-      redirect_to job_seeker_path(@job_seeker), alert: '経歴書の削除に失敗しました。'
-    end
+    @job_seeker = JobSeeker.find(params[:job_seeker_id])
+    @job_seeker.resume.destroy
+    redirect_to job_seeker_path(@job_seeker), notice: '経歴書を削除しました。'
   end
 
   private

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -30,9 +30,7 @@ class RoomsController < ApplicationController
   def authenticate_user!
     return if job_offerer_signed_in? || job_seeker_signed_in?
 
-    return authenticate_job_offerer! unless job_offerer_signed_in?
-
-    return authenticate_job_seeker! unless job_seeker_signed_in?
+    redirect_to root_url, alert: 'この機能はログインが必要です'
   end
 
   def entry_params

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -14,8 +14,7 @@ class RoomsController < ApplicationController
       @room = Room.find(params[:id])
       @messages = @room.messages
     else
-      redirect_back(fallback_location: root_path)
-      flash[:alert] = '権限がありません'
+      redirect_back(fallback_location: root_path, alert: '権限がありません')
     end
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,5 +1,8 @@
 class RoomsController < ApplicationController
+  include Common
+
   before_action :authenticate_user!
+  before_action :require_profile
 
   def index
     @rooms = current_user.rooms.order(updated_at: :desc)

--- a/app/views/home/home.html.slim
+++ b/app/views/home/home.html.slim
@@ -4,6 +4,10 @@ h1.center-align
   p.center-align
     | こんにちは、
     = current_job_offerer.email
+- elsif job_seeker_signed_in?
+  p.center-align
+    | こんにちは、
+    = current_job_seeker.email
 - else  
   p.center-align
     | ここはJOBLINKのHomeページです

--- a/app/views/job_offerers/job_postings/index.html.slim
+++ b/app/views/job_offerers/job_postings/index.html.slim
@@ -11,7 +11,8 @@ h2
         p
           == job_posting.content
   = paginate @job_postings
-.section
-  .row
-    .right
-      = link_to '求人を投稿する', new_job_posting_path, class: 'btn'
+- if job_offerer_signed_in?
+  .section
+    .row
+      .right
+        = link_to '求人を投稿する', new_job_posting_path, class: 'btn'

--- a/app/views/job_offerers/job_postings/show.html.slim
+++ b/app/views/job_offerers/job_postings/show.html.slim
@@ -10,10 +10,11 @@
     p
       == @job_posting.content
 .section
-  .row
-    .right
-      = link_to '編集', edit_job_posting_path, class: 'btn'
-      =< link_to '削除', job_posting_path, data: { confirm: "この求人を削除しますか?" }, method: :delete, class: 'btn'
+  - if @job_posting.job_offerer == current_job_offerer
+    .row
+      .right
+        = link_to '編集', edit_job_posting_path, class: 'btn'
+        =< link_to '削除', job_posting_path, data: { confirm: "この求人を削除しますか?" }, method: :delete, class: 'btn'
   .row
     .right
       = link_to '一覧へ戻る', job_postings_path

--- a/app/views/job_offerers/profiles/edit.html.slim
+++ b/app/views/job_offerers/profiles/edit.html.slim
@@ -1,6 +1,6 @@
 h3
   | プロフィールの編集
-= form_with model: @profile, local: true do |f|
+= form_with model: @profile, url: job_offerer_profile_path, local: true do |f|
   = render 'layouts/error_messages', model: f.object
   .row.valign-wrapper
     .col.s6

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -26,4 +26,4 @@
 - if correct_user?
   .section
     .row
-      = link_to 'アカウント設定', edit_job_offerer_registration_path(current_job_offerer)
+      = link_to 'アカウント設定', edit_job_offerer_registration_path

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -5,7 +5,8 @@
     - else
       = image_tag '/default_avatar.png', class: 'circle responsive-img', size: '200x200'
   .col.s2.offset-s2.right
-    = link_to '編集', edit_job_offerer_profile_path(@profile), class: 'btn'
+    - if correct_user?
+      = link_to '編集', edit_job_offerer_profile_path(@profile), class: 'btn'
     - if job_seeker_signed_in?
       - if current_job_seeker.rooms.find_by(id: @job_offerer.rooms)
         =< link_to 'メッセージ', room_path(current_job_seeker.rooms.find_by(id: @job_offerer.rooms)), class: 'btn'
@@ -22,6 +23,7 @@
       = @profile.job_offerer.email
   blockquote
     = @profile.bio
-.section
-  .row
-    = link_to 'アカウント設定', edit_job_offerer_registration_path(current_job_offerer)
+- if correct_user?
+  .section
+    .row
+      = link_to 'アカウント設定', edit_job_offerer_registration_path(current_job_offerer)

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -6,7 +6,7 @@
       = image_tag '/default_avatar.png', class: 'circle responsive-img', size: '200x200'
   .col.s2.offset-s2.right
     - if correct_user?
-      = link_to '編集', edit_job_offerer_profile_path(@profile), class: 'btn'
+      = link_to '編集', edit_job_offerer_profile_path(@job_offerer), class: 'btn'
     - if job_seeker_signed_in?
       - if current_job_seeker.rooms.find_by(id: @job_offerer.rooms)
         =< link_to 'メッセージ', room_path(current_job_seeker.rooms.find_by(id: @job_offerer.rooms)), class: 'btn'

--- a/app/views/job_seekers/profiles/edit.html.slim
+++ b/app/views/job_seekers/profiles/edit.html.slim
@@ -1,6 +1,6 @@
 h3
   | プロフィールの編集
-= form_with model: @profile, local: true do |f|
+= form_with model: @profile, url: job_seeker_profile_path, local: true do |f|
   = render 'layouts/error_messages', model: f.object
   .row.valign-wrapper
     .col.s6

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -29,4 +29,4 @@
 - if correct_user?
   .section
     .row
-      = link_to 'アカウント設定', edit_job_seeker_registration_path(current_job_seeker)
+      = link_to 'アカウント設定', edit_job_seeker_registration_path

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -5,8 +5,8 @@
     - else
       = image_tag '/default_avatar.png', class: 'circle responsive-img', size: '200x200'
   .col.s2.offset-s2.right
-    - if correct_user?  
-      = link_to '編集', edit_job_seeker_profile_path(@profile), class: 'btn'
+    - if correct_user?
+      = link_to '編集', edit_job_seeker_profile_path(@job_seeker), class: 'btn'
     - if job_offerer_signed_in?
       - if current_job_offerer.rooms.find_by(id: @job_seeker.rooms)
         =< link_to 'メッセージ', room_path(current_job_offerer.rooms.find_by(id: @job_seeker.rooms)), class: 'btn'

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -5,7 +5,8 @@
     - else
       = image_tag '/default_avatar.png', class: 'circle responsive-img', size: '200x200'
   .col.s2.offset-s2.right
-    = link_to '編集', edit_job_seeker_profile_path(@profile), class: 'btn'
+    - if correct_user?  
+      = link_to '編集', edit_job_seeker_profile_path(@profile), class: 'btn'
     - if job_offerer_signed_in?
       - if current_job_offerer.rooms.find_by(id: @job_seeker.rooms)
         =< link_to 'メッセージ', room_path(current_job_offerer.rooms.find_by(id: @job_seeker.rooms)), class: 'btn'
@@ -25,6 +26,7 @@
 .section
   h4 経歴書
   = render 'job_seekers/resumes/sheet'
-.section
-  .row
-    = link_to 'アカウント設定', edit_job_seeker_registration_path(current_job_seeker)
+- if correct_user?
+  .section
+    .row
+      = link_to 'アカウント設定', edit_job_seeker_registration_path(current_job_seeker)


### PR DESCRIPTION
### 権限による機能の制限を追加

ユーザーの編集・機能アクセス制限の設定を追加した。
- プロフィール
  - 他のユーザーからは編集できないように変更
  - プロフィールが既に設定されている時はnewアクションを実行できないように変更
- 経歴書
  - 他のユーザーからは作成・編集・削除できないように変更
  - プロフィールを登録していない状態では操作できないように変更
- 投稿
  - 投稿主以外からは編集・削除できないように変更
  - プロフィールを登録していない状態では操作できないように変更
- チャット
  - プロフィールを登録していない状態では操作できないように変更

これらを実現するいくつかのメソッドは'controllers/concerns'に共通化してある。

> 参考: 
> (https://programming-beginner-zeroichi.jp/articles/142)
> (https://qiita.com/sibakenY/items/0f0cdfcd5f8418151b12)
> (https://qiita.com/shizuma/items/ae6ecb85615f74444693)