### PR TITLE
Feature/admin

### DIFF
--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -5,6 +5,12 @@ module Common
     @tags = ActsAsTaggableOn::Tag.most_used(12)
   end
 
+  def require_admin
+    return unless current_user.admin == false
+
+    redirect_back(fallback_location: root_path, alert: '権限がありません')
+  end
+
   def require_profile
     return unless current_user.profile.nil?
 

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -41,6 +41,12 @@ class JobOfferers::ProfilesController < ApplicationController
     end
   end
 
+  def destroy
+    @job_offerer = JobOfferer.find(params[:id])
+    @job_offerer.destroy
+    redirect_to job_offerers_path, notice: '求人者を削除しました。'
+  end
+
   private
 
   def profile_params

--- a/app/controllers/job_offerers/profiles_controller.rb
+++ b/app/controllers/job_offerers/profiles_controller.rb
@@ -1,9 +1,10 @@
 class JobOfferers::ProfilesController < ApplicationController
   include Common
 
-  before_action :authenticate_job_offerer!, except: %i[index show]
+  before_action :authenticate_job_offerer!, except: %i[index show destroy]
   before_action :profile_exists_already, only: %i[new create]
   before_action :require_correct_user, only: %i[edit update]
+  before_action :require_admin, only: %i[destroy]
 
   def index
     popular_tags

--- a/app/controllers/job_offerers/registrations_controller.rb
+++ b/app/controllers/job_offerers/registrations_controller.rb
@@ -25,9 +25,13 @@ class JobOfferers::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    if resource == current_user && current_user.admin?
+      redirect_back(fallback_location: root_path, alert: '管理者は削除できません')
+    else
+      super
+    end
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -1,9 +1,10 @@
 class JobSeekers::ProfilesController < ApplicationController
   include Common
 
-  before_action :authenticate_job_seeker!, except: %i[index show]
+  before_action :authenticate_job_seeker!, except: %i[index show destroy]
   before_action :profile_exists_already, only: %i[new create]
   before_action :require_correct_user, only: %i[edit update]
+  before_action :require_admin, only: %i[destroy]
 
   def index
     popular_tags

--- a/app/controllers/job_seekers/profiles_controller.rb
+++ b/app/controllers/job_seekers/profiles_controller.rb
@@ -41,6 +41,12 @@ class JobSeekers::ProfilesController < ApplicationController
     end
   end
 
+  def destroy
+    @job_seeker = JobSeeker.find(params[:id])
+    @job_seeker.destroy
+    redirect_to job_seekers_path, notice: '求職者を削除しました。'
+  end
+
   private
 
   def profile_params

--- a/app/controllers/job_seekers/registrations_controller.rb
+++ b/app/controllers/job_seekers/registrations_controller.rb
@@ -25,9 +25,13 @@ class JobSeekers::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    if resource == current_user && current_user.admin?
+      redirect_back(fallback_location: root_path, alert: '管理者は削除できません')
+    else
+      super
+    end
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,4 +19,8 @@ module ApplicationHelper
     return true if controller.controller_name == 'rooms' &&
                    controller.action_name == 'show'
   end
+
+  def user_signed_in?
+    return true if job_offerer_signed_in? || job_seeker_signed_in?
+  end
 end

--- a/app/views/job_offerers/profiles/index.html.slim
+++ b/app/views/job_offerers/profiles/index.html.slim
@@ -22,13 +22,13 @@ h4
         = link_to(job_offerer_path(profile.job_offerer), class: 'collection-item avatar black-text') do
           - if profile.avatar.attached?
             = image_tag profile.shaped_avatar, class: 'circle'
-            span.title
-              = profile.full_name
-            p
-              = profile.bio
-            - profile.tag_list.each do |tag|
-              span.chip
-                = tag
+          span.title
+            = profile.full_name
+          p
+            = profile.bio
+          - profile.tag_list.each do |tag|
+            span.chip
+              = tag
   - else
     .row
       p お探しの条件に該当する結果が見つかりませんでした。

--- a/app/views/job_offerers/profiles/index.html.slim
+++ b/app/views/job_offerers/profiles/index.html.slim
@@ -22,6 +22,8 @@ h4
         = link_to(job_offerer_path(profile.job_offerer), class: 'collection-item avatar black-text') do
           - if profile.avatar.attached?
             = image_tag profile.shaped_avatar, class: 'circle'
+          - else 
+            = image_tag '/default_avatar.png', class: 'circle'
           span.title
             = profile.full_name
           p

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -32,3 +32,7 @@
   .section
     .row
       = link_to 'アカウント設定', edit_job_offerer_registration_path
+- if user_signed_in?
+  - if current_user.admin? && @job_offerer != current_user
+    .row
+      = link_to 'この求人者を削除', job_offerer_path(@job_offerer), data: { confirm: "この求人者を削除しますか?" }, method: :delete

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -28,11 +28,11 @@
   .row
     - @profile.tag_list.each do |tag|
       = link_to tag, job_offerers_path(tag_name: tag), class: 'chip'
-- if correct_user?
-  .section
-    .row
-      = link_to 'アカウント設定', edit_job_offerer_registration_path
 - if user_signed_in?
-  - if current_user.admin? && @job_offerer != current_user
-    .row
-      = link_to 'この求人者を削除', job_offerer_path(@job_offerer), data: { confirm: "この求人者を削除しますか?" }, method: :delete
+  .section
+    - if correct_user?
+      .row
+        = link_to 'アカウント設定', edit_job_offerer_registration_path
+    - if current_user.admin? && @job_offerer != current_user
+      .row
+        = link_to 'この求人者を削除', job_offerer_path(@job_offerer), data: { confirm: "この求人者を削除しますか?" }, method: :delete

--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -19,6 +19,8 @@
           = @profile.full_name
         rt
           = @profile.full_name_furigana
+      - if correct_user? && @job_offerer.admin?
+        i.material-icons check_circle
     p
       = @profile.job_offerer.email
   blockquote

--- a/app/views/job_offerers/registrations/edit.html.slim
+++ b/app/views/job_offerers/registrations/edit.html.slim
@@ -37,18 +37,19 @@
     .row
       .actions
         = f.submit "更新", class: 'btn right'
-.divider
-.section
-  h3
-    | アカウントを削除する
-  .row
-    p
-      | サービスが気に入りませんでしたか？
-      br
-      | 以下のリンクからアカウントを削除できます。
-  .row
-    = link_to "退会する", job_offerer_registration_path, data: { confirm: "本当に退会しますか?" }, method: :delete
-    p
-      | *削除したアカウントは完全に復元できなくなります
-  .row  
-    = link_to "戻る", :back, class: 'btn right'
+- unless current_user.admin?
+  .divider
+  .section
+    h3
+      | アカウントを削除する
+    .row
+      p
+        | サービスが気に入りませんでしたか？
+        br
+        | 以下のリンクからアカウントを削除できます。
+    .row
+      = link_to "退会する", job_offerer_registration_path, data: { confirm: "本当に退会しますか?" }, method: :delete
+      p
+        | *削除したアカウントは完全に復元できなくなります
+    .row  
+      = link_to "戻る", :back, class: 'btn right'

--- a/app/views/job_seekers/profiles/index.html.slim
+++ b/app/views/job_seekers/profiles/index.html.slim
@@ -22,6 +22,8 @@ h4
         = link_to(job_seeker_path(profile.job_seeker), class: 'collection-item avatar black-text') do
           - if profile.avatar.attached?
             = image_tag profile.shaped_avatar, class: 'circle'
+          - else 
+            = image_tag '/default_avatar.png', class: 'circle'
           span.title
             = profile.full_name
           p

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -19,6 +19,8 @@
           = @profile.full_name
         rt
           = @profile.full_name_furigana
+      - if correct_user? && @job_seeker.admin?
+        i.material-icons check_circle
     p
       = @profile.job_seeker.email
   blockquote

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -45,11 +45,11 @@
       .section
         p 求人をブックマークしていません。
         = link_to '求人を探す', job_postings_path
-- if correct_user?
-  .section
-    .row
-      = link_to 'アカウント設定', edit_job_seeker_registration_path
 - if user_signed_in?
-  - if current_user.admin? && @job_seeker != current_user
-    .row
-      = link_to 'この求職者を削除', job_seeker_path(@job_seeker), data: { confirm: "この求職者を削除しますか?" }, method: :delete
+  .section
+    - if correct_user?
+      .row
+        = link_to 'アカウント設定', edit_job_seeker_registration_path
+    - if current_user.admin? && @job_seeker != current_user
+      .row
+        = link_to 'この求職者を削除', job_seeker_path(@job_seeker), data: { confirm: "この求職者を削除しますか?" }, method: :delete

--- a/app/views/job_seekers/profiles/show.html.slim
+++ b/app/views/job_seekers/profiles/show.html.slim
@@ -49,3 +49,7 @@
   .section
     .row
       = link_to 'アカウント設定', edit_job_seeker_registration_path
+- if user_signed_in?
+  - if current_user.admin? && @job_seeker != current_user
+    .row
+      = link_to 'この求職者を削除', job_seeker_path(@job_seeker), data: { confirm: "この求職者を削除しますか?" }, method: :delete

--- a/app/views/job_seekers/registrations/edit.html.slim
+++ b/app/views/job_seekers/registrations/edit.html.slim
@@ -37,18 +37,19 @@
     .row
       .actions
         = f.submit "更新", class: 'btn right'
-.divider
-.section
-  h3
-    | アカウントを削除する
-  .row
-    p
-      | サービスが気に入りませんでしたか？
-      br
-      | 以下のリンクからアカウントを削除できます。
-  .row
-    = link_to "退会する", job_seeker_registration_path, data: { confirm: "本当に退会しますか?" }, method: :delete
-    p
-      | *削除したアカウントは完全に復元できなくなります
-  .row  
-    = link_to "戻る", :back, class: 'btn right'
+- unless current_user.admin?
+  .divider
+  .section
+    h3
+      | アカウントを削除する
+    .row
+      p
+        | サービスが気に入りませんでしたか？
+        br
+        | 以下のリンクからアカウントを削除できます。
+    .row
+      = link_to "退会する", job_seeker_registration_path, data: { confirm: "本当に退会しますか?" }, method: :delete
+      p
+        | *削除したアカウントは完全に復元できなくなります
+    .row  
+      = link_to "戻る", :back, class: 'btn right'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
 
   scope module: :job_offerers do
-    resources :job_offerers, only: %i[index show], controller: :profiles do
+    resources :job_offerers, only: %i[index show destroy], controller: :profiles do
       resource :profile, except: %i[show destroy]
     end
   end
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   end
 
   scope module: :job_seekers do
-    resources :job_seekers, only: %i[index show], controller: :profiles do
+    resources :job_seekers, only: %i[index show destroy], controller: :profiles do
       resource :profile, except: %i[show destroy]
       resource :resume, except: %i[index show]
     end

--- a/db/migrate/20200209123055_add_admin_to_job_offerers.rb
+++ b/db/migrate/20200209123055_add_admin_to_job_offerers.rb
@@ -1,0 +1,5 @@
+class AddAdminToJobOfferers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :job_offerers, :admin, :boolean, default: false
+  end
+end

--- a/db/migrate/20200209133514_add_admin_to_job_seekers.rb
+++ b/db/migrate/20200209133514_add_admin_to_job_seekers.rb
@@ -1,0 +1,5 @@
+class AddAdminToJobSeekers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :job_seekers, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_123055) do
+ActiveRecord::Schema.define(version: 2020_02_09_133514) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 2020_02_09_123055) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false
     t.index ["confirmation_token"], name: "index_job_seekers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_job_seekers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_job_seekers_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_07_001353) do
+ActiveRecord::Schema.define(version: 2020_02_09_123055) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2020_02_07_001353) do
     t.datetime "locked_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false
     t.index ["confirmation_token"], name: "index_job_offerers_on_confirmation_token", unique: true
     t.index ["email"], name: "index_job_offerers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_job_offerers_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,16 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+admin = JobOfferer.create!(
+  email: ENV['ADMIN_EMAIL'],
+  password: ENV['ADMIN_PASSWORD'],
+  confirmed_at: Time.now,
+  admin: true
+)
+admin.create_profile!(
+  first_name: '大暉',
+  last_name: '上窪',
+  first_name_furigana: 'だいき',
+  last_name_furigana: 'うえくぼ',
+  bio: 'ご利用ありがとうございます。'
+)


### PR DESCRIPTION
### 管理ユーザー機能を追加

ユーザーに管理者権限のカラムを追加し、管理者権限の状態を持たせられるようにした。
デフォルトはfalse。

管理ユーザーは以下の特徴を持つ。
- 他ユーザーの削除
- 自らのアカウントを削除できない

seedデータに管理者として初期ユーザーを追加し、データベースをリセットしても管理者を'db:seed'で作成できるようにした。
この初期ユーザーのログインemailとpasswordは、第三者にログインしてユーザーを消したりされないよう環境変数(.zprofile)で設定してある。