### PR TITLE
Fix: フォームのラベルをクリックしても動作しない不具合を修正

### DIFF
--- a/app/views/job_offerers/profiles/_form.html.slim
+++ b/app/views/job_offerers/profiles/_form.html.slim
@@ -14,33 +14,33 @@
       = f.text_field :file_path, class: 'file-path validate'
 .row
   .input-field.col.s6
-    = f.label '姓'
+    = f.label :last_name
     = f.text_field :last_name
     span.helper-text
       | *必須項目
   .input-field.col.s6
-    = f.label '名'
+    = f.label :first_name
     = f.text_field :first_name
     span.helper-text
       | *必須項目
 .row
   .input-field.col.s6
-    = f.label '姓(ふりがな)'
+    = f.label :last_name_furigana
     = f.text_field :last_name_furigana
     span.helper-text
       | *必須項目
   .input-field.col.s6
-    = f.label '名(ふりがな)'
+    = f.label :first_name_furigana
     = f.text_field :first_name_furigana
     span.helper-text
       | *必須項目
 .row
   .input-field.col.s12
-    = f.label '自己紹介'
+    = f.label :bio
     = f.text_area :bio, class: 'materialize-textarea character_limit', data: {length: '160'}
 .row
   .input-field.col.s12
-    = f.label 'タグ'
+    = f.label :tag_list
     = f.text_field :tag_list, value: @profile.tag_list.join(',' + ' ')
     span.helper-text
       | *コンマまたはスペース区切りで複数入力可能

--- a/app/views/job_postings/_form.html.slim
+++ b/app/views/job_postings/_form.html.slim
@@ -15,11 +15,11 @@
       | *画像を選択するとプレビューを表示します
 .row
   .input-field
-    = f.label 'タイトル'
+    = f.label :title
     = f.text_field :title
 .row
   .input-field 
-    = f.label 'タグ'
+    = f.label :tag_list
     = f.text_field :tag_list, value: @job_posting.tag_list.join(',' + ' ')
     span.helper-text
       | *コンマまたはスペース区切りで複数入力可能

--- a/app/views/job_seekers/profiles/_form.html.slim
+++ b/app/views/job_seekers/profiles/_form.html.slim
@@ -14,33 +14,33 @@
       = f.text_field :file_path, class: 'file-path validate'
 .row
   .input-field.col.s6
-    = f.label '姓'
+    = f.label :last_name
     = f.text_field :last_name
     span.helper-text
       | *必須項目
   .input-field.col.s6
-    = f.label '名'
+    = f.label :first_name
     = f.text_field :first_name
     span.helper-text
       | *必須項目
 .row
   .input-field.col.s6
-    = f.label '姓(ふりがな)'
+    = f.label :last_name_furigana
     = f.text_field :last_name_furigana
     span.helper-text
       | *必須項目
   .input-field.col.s6
-    = f.label '名(ふりがな)'
+    = f.label :first_name_furigana
     = f.text_field :first_name_furigana
     span.helper-text
       | *必須項目
 .row
   .input-field.col.s12
-    = f.label '自己紹介'
+    = f.label :bio
     = f.text_area :bio, class: 'materialize-textarea character_limit', data: {length: '160'}
 .row
   .input-field.col.s12
-    = f.label 'タグ'
+    = f.label :tag_list
     = f.text_field :tag_list, value: @profile.tag_list.join(',' + ' ')
     span.helper-text
       | *コンマまたはスペース区切りで複数入力可能

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,16 +7,21 @@ ja:
         last_name: 姓
         first_name_furigana: 名(ふりがな)
         last_name_furigana: 姓(ふりがな)
+        bio: 自己紹介
+        tag_list: タグ
       job_seeker_profile:
         avatar: アバター
         first_name: 名
         last_name: 姓
         first_name_furigana: 名(ふりがな)
         last_name_furigana: 姓(ふりがな)
+        bio: 自己紹介
+        tag_list: タグ
       job_posting:
         header: ヘッダー
         title: タイトル
         content: 本文
+        tag_list: タグ
       resume:
         content: 本文
   views:


### PR DESCRIPTION
'姓','名'などのラベルが反応しなかったので、動作するように修正。
labelのidとフィールドのidが一致していなかったためと思われるので、シンボルで指定し、localeで日本語表示するようにした。