### PR TITLE
Fix: ActionTextで箇条書きのbulletsが表示されない不具合を修正

### DIFF
--- a/app/frontend/stylesheets/actiontext.scss
+++ b/app/frontend/stylesheets/actiontext.scss
@@ -38,3 +38,17 @@
 trix-editor {
   min-height: 30em;
 }
+
+.trix-editor {
+  ul:not(.browser-default) > li {
+    list-style-type: disc;
+    display: list-item;
+  }
+}
+
+.trix-content {
+  ul:not(.browser-default) > li {
+    list-style-type: disc;
+    display: list-item;
+  }
+}


### PR DESCRIPTION
MaterializeCSSはデフォルトで<ul>や<li>にアイコンがつかないように設定されてように設定されているので、trix-content, trix-editor内でのみbulletsを許容するように設定を追記した。