### PR TITLE
Change: 管理者のメールアドレスを非表示に変更

### DIFF
--- a/app/views/job_offerers/profiles/show.html.slim
+++ b/app/views/job_offerers/profiles/show.html.slim
@@ -20,7 +20,10 @@
       - if correct_user? && @job_offerer.admin?
         i.material-icons check_circle
     p
-      = @profile.job_offerer.email
+      - if @job_offerer.admin?
+        | @administrator
+      - else
+        = @profile.job_offerer.email
   h6
     = @profile.bio
   .row


### PR DESCRIPTION
一般ユーザーから万が一にも勝手にログインされないようにメールアドレスを非公開にし、変わりに管理者であることを示す'@administrator'を表示する。