### PR TITLE
Add: レスポンシブデザインに対応する設定を追加

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,6 +6,7 @@ html
     = csrf_meta_tags
     = csp_meta_tag
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
     link[href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"]
   body
     - if room?


### PR DESCRIPTION
headタグにデバイスのウィンドウサイズに対応してコンテンツの幅を調整するタグを追加した。
これでレスポンシブ対応できるそうだ。