### PR TITLE
Fix: 求職者のアカウント登録/ログインページの誤字を修正

### DIFF
--- a/app/views/job_seekers/registrations/new.html.slim
+++ b/app/views/job_seekers/registrations/new.html.slim
@@ -1,6 +1,6 @@
 .container
   h2
-    | 求人者
+    | 求職者
     =< t('.sign_up')
   = form_with model: @job_seeker, local: true do |f|
     = devise_error_messages!

--- a/app/views/job_seekers/sessions/new.html.slim
+++ b/app/views/job_seekers/sessions/new.html.slim
@@ -1,6 +1,6 @@
 .container
   h2
-    | 求人者
+    | 求職者
     =< t('.sign_in')
   = form_with model: @job_seeker, url: job_seeker_session_path, local: true do |f|
     .row


### PR DESCRIPTION
'求人者'になってしまっていた。
正しくは'求職者'。